### PR TITLE
Auto-Update

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+name: Docker Upload.
+description: Automatically build and publish to registry using latest and git ref as tags.
+author: poggit
+
+on:
+  repository_dispatch:
+    types: [update]
+    
+jobs:
+  update:
+    name: Docker update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run docker action.
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: JaxkDev/poggit-phpstan
+          tags: latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,8 @@ jobs:
     name: Docker update
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout v1
+        uses: actions/checkout@v1
       - name: Run docker action.
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,9 @@
 name: Docker Upload.
-description: Automatically build and publish to registry using latest and git ref as tags.
-author: poggit
 
 on:
   repository_dispatch:
     types: [update]
-    
+
 jobs:
   update:
     name: Docker update
@@ -16,5 +14,5 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: JaxkDev/poggit-phpstan
+          repository: jaxkdev/poggit-phpstan
           tags: latest


### PR DESCRIPTION
Images are built and published to latest tag whenever a dispatch_event is sent to github (https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) I've already got a small server doing things whenever a new pmmp update is released i can piggy back on that to send that data.

Tested on fork works perfectly, only issue would be poggit cache.
I'm not entirely sure if docker checks if the tag matches the data of the same tag on the registry if it doesn't that'd mean either changing this to tag the API version (AND updating poggit to detect latest api tag), or refreshing the local tag 'latest' with the updated one.